### PR TITLE
how to test easily with Mockery

### DIFF
--- a/src/RateLimited.php
+++ b/src/RateLimited.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\RateLimitedMiddleware;
 
-use Redis;
+use Illuminate\Support\Facades\Redis;
 
 class RateLimited
 {
@@ -42,7 +42,7 @@ class RateLimited
 
     public function timespanInSeconds(int $timespanInSeconds)
     {
-        $this->timespanInSeconds = $timespanInSeconds;
+        $this->timeSpanInSeconds = $timespanInSeconds;
 
         return $this;
     }
@@ -75,7 +75,7 @@ class RateLimited
             ->then(function () use ($job, $next) {
                 $next($job);
             }, function () use ($job) {
-                $job->release($this->timeSpanInSeconds);
+                $job->release($this->releaseInSeconds);
             });
     }
 }

--- a/tests/RateLimitedTest.php
+++ b/tests/RateLimitedTest.php
@@ -2,14 +2,87 @@
 
 namespace Spatie\RateLimitedMiddleware\Tests;
 
+use Closure;
+use Illuminate\Support\Facades\Redis;
+use Mockery;
 use Orchestra\Testbench\TestCase;
 use Spatie\RateLimitedMiddleware\RateLimited;
 
 class RateLimitedTest extends TestCase
 {
-    /** @test */
-    public function it_can_be_instanciated()
+    /** @var Closure */
+    private $next;
+    /** @var Mockery\Mock */
+    private $job;
+    /** @var Mockery\Mock */
+    private $redis;
+
+    /** @var RateLimited */
+    private $middleware;
+
+    protected function setUp(): void
     {
-        $this->assertInstanceOf(RateLimited::class, new RateLimited());
+        parent::setUp();
+
+        $this->redis = Mockery::mock();
+        $this->job = Mockery::mock();
+        $this->next = function ($job) {
+            $job->fire(); // just anything on the $job so we can ensure it gets called
+        };
+
+        $this->middleware = new RateLimited();
+    }
+
+    /** @test */
+    public function does_the_job_when_enabled()
+    {
+        $this->middleware->enabled(true);
+
+        // a bit of exaggeration here just to map setters to underlying laravel's calls:
+        $this->middleware->connectionName('my-connection');
+        Redis::shouldReceive('connection')->with('my-connection')->andReturn($this->redis);
+
+        $this->middleware->key('my-key');
+        $this->redis->shouldReceive('throttle')->once()->with('my-key')->andReturn($this->redis);
+
+        $this->middleware->timespanInSeconds(60);
+        $this->redis->shouldReceive('every')->once()->with(60)->andReturnSelf();
+
+        $this->middleware->allowedNumberOfJobsInTimeSpan(3);
+        $this->redis->shouldReceive('allow')->once()->with(3)->andReturnSelf();
+
+        // this one will apply on the job in case of throttling
+        $this->middleware->releaseInSeconds(90);
+        $jobThrottled = function ($callback) {
+            $this->job->shouldReceive('release')->once()->with(90);
+            $callback();
+            return true;
+        };
+
+        $jobAllowed = function ($callback) {
+            $this->job->shouldReceive('fire')->once();
+            $callback();
+            return true;
+        };
+
+        $this->redis->shouldReceive('then')->once()->with(
+            Mockery::on($jobAllowed),
+            Mockery::on($jobThrottled),
+        );
+
+        // This one is simply hard-coded to 0
+        $this->redis->shouldReceive('block')->once()->with(0)->andReturnSelf();
+
+        $this->middleware->handle($this->job, $this->next);
+    }
+
+    /** @test */
+    public function stops_when_disabled()
+    {
+        Redis::shouldReceive('connection')->never();
+        $this->job->shouldReceive('fire')->once();
+        $this->middleware->enabled(false);
+
+        $this->middleware->handle($this->job, $this->next);
     }
 }

--- a/tests/RateLimitedTest.php
+++ b/tests/RateLimitedTest.php
@@ -3,9 +3,9 @@
 namespace Spatie\RateLimitedMiddleware\Tests;
 
 use Closure;
-use Illuminate\Support\Facades\Redis;
 use Mockery;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Redis;
 use Spatie\RateLimitedMiddleware\RateLimited;
 
 class RateLimitedTest extends TestCase
@@ -56,12 +56,14 @@ class RateLimitedTest extends TestCase
         $jobThrottled = function ($callback) {
             $this->job->shouldReceive('release')->once()->with(90);
             $callback();
+
             return true;
         };
 
         $jobAllowed = function ($callback) {
             $this->job->shouldReceive('fire')->once();
             $callback();
+
             return true;
         };
 


### PR DESCRIPTION
Laravel beautifully hides a lot of complexity behind easy and nice API. When it comes to testing it might be a bit tough to know how to approach it best, so here's my shot on that:

## very short tests with faking only the redis service #5
here we fake the redis service and ignore setters coverage, just to get the tests as short and intuitive as possible

## stricter and safer approach with `PHPUnit` mocks #3
**pro:** it's safe in that when Laravel breaks something in the internal APIs (which happens A LOT as we know it), say, method `allow` becomes `allows` -> this will catch it instantly and you can adjust your own code
**con:** it's a bit more verbose and requires knowledge about the underlying flow (eg. we have to know that `Redis::connection()->throttle()->something()->else()` chain is actually not a fluent interface on single instance, but a chain on several classes

## a bit loose approach with `Mockery` mocks #2
**pro** & **con** pretty much the opposite of the above - no need to know internal flow, but if it ever breaks we may learn about in production..