### PR TITLE
No need for Laravel package discovery options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,15 +41,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Spatie\\RateLimitedMiddleware\\RateLimitedMiddlewareServiceProvider"
-            ],
-            "aliases": {
-                "RateLimitedMiddleware": "Spatie\\RateLimitedMiddleware\\RateLimitedMiddlewareFacade"
-            }
-        }
     }
 }


### PR DESCRIPTION
As this package is not registering itself automatically (we do not have a service provider either), there is no need to Laravel package discovery options on the composer file.