### PR TITLE
how to test with fake redis

### DIFF
--- a/src/RateLimited.php
+++ b/src/RateLimited.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\RateLimitedMiddleware;
 
-use Redis;
+use Illuminate\Support\Facades\Redis;
 
 class RateLimited
 {
@@ -42,7 +42,7 @@ class RateLimited
 
     public function timespanInSeconds(int $timespanInSeconds)
     {
-        $this->timespanInSeconds = $timespanInSeconds;
+        $this->timeSpanInSeconds = $timespanInSeconds;
 
         return $this;
     }
@@ -75,7 +75,7 @@ class RateLimited
             ->then(function () use ($job, $next) {
                 $next($job);
             }, function () use ($job) {
-                $job->release($this->timeSpanInSeconds);
+                $job->release($this->releaseInSeconds);
             });
     }
 }

--- a/tests/RateLimitedTest.php
+++ b/tests/RateLimitedTest.php
@@ -2,14 +2,76 @@
 
 namespace Spatie\RateLimitedMiddleware\Tests;
 
+use Closure;
+use Mockery;
 use Orchestra\Testbench\TestCase;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Redis\Connections\Connection;
 use Spatie\RateLimitedMiddleware\RateLimited;
+use Illuminate\Redis\Limiters\DurationLimiterBuilder;
 
 class RateLimitedTest extends TestCase
 {
-    /** @test */
-    public function it_can_be_instanciated()
+    /** @var Closure */
+    private $next;
+    /** @var Mockery\Mock */
+    private $job;
+    /** @var Mockery\Mock */
+    private $redis;
+
+    /** @var int Fake redis lock */
+    private $callsAllowed;
+
+    /** @var RateLimited */
+    private $middleware;
+
+    protected function setUp(): void
     {
-        $this->assertInstanceOf(RateLimited::class, new RateLimited());
+        parent::setUp();
+        $this->callsAllowed = 2;
+        $this->mockRedis();
+        $this->mockJob();
+        $this->middleware = new RateLimited();
+    }
+
+    /** @test */
+    public function it_limits_job_execution()
+    {
+        $this->job->shouldReceive('fire')->times(2);
+        $this->job->shouldReceive('release')->times(3);
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->middleware->handle($this->job, $this->next);
+        }
+    }
+
+    /** @test */
+    public function it_does_nothing_when_disabled()
+    {
+        $this->job->shouldReceive('fire')->times(1);
+        $this->middleware->enabled(false)->handle($this->job, $this->next);
+    }
+
+    private function mockRedis(): void
+    {
+        // Let's mock redis service and its lock mechanism so we can test our stuff without hassle
+        $this->redis = Mockery::mock(Connection::class);
+        $this->redis->shouldReceive('throttle')->andReturn(new DurationLimiterBuilder($this->redis, 'key'));
+        $this->redis->shouldReceive('eval')->andReturnUsing(function () {
+            return [
+                $this->callsAllowed > 0,
+                strtotime('10 seconds'),
+                $this->callsAllowed--,
+            ];
+        });
+        Redis::shouldReceive('connection')->andReturn($this->redis);
+    }
+
+    private function mockJob(): void
+    {
+        $this->job = Mockery::mock();
+        $this->next = function ($job) {
+            $job->fire();
+        };
     }
 }


### PR DESCRIPTION
Laravel beautifully hides a lot of complexity behind easy and nice API. When it comes to testing it might be a bit tough to know how to approach it best, so here's my shot on that:

## very short tests with faking only the redis service #5
here we fake the redis service and ignore setters coverage, just to get the tests as short and intuitive as possible

## stricter and safer approach with `PHPUnit` mocks #3
**pro:** it's safe in that when Laravel breaks something in the internal APIs (which happens A LOT as we know it), say, method `allow` becomes `allows` -> this will catch it instantly and you can adjust your own code
**con:** it's a bit more verbose and requires knowledge about the underlying flow (eg. we have to know that `Redis::connection()->throttle()->something()->else()` chain is actually not a fluent interface on single instance, but a chain on several classes

## a bit loose approach with `Mockery` mocks #2
**pro** & **con** pretty much the opposite of the above - no need to know internal flow, but if it ever breaks we may learn about in production..