### PR TITLE
add release duration callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ These methods are available to be called on the middleware. Their names should b
 - `releaseAfterSeconds(int $releaseInSeconds)`
 - `releaseAfterOneMinute()`
 - `releaseAfterMinutes(int $releaseInSeconds)`
+- `releaseAfter(callable $releaseAfter)`
 
 ### Testing
 

--- a/src/RateLimited.php
+++ b/src/RateLimited.php
@@ -156,5 +156,4 @@ class RateLimited
                 $job->release($this->releaseDuration($job));
             });
     }
-
 }

--- a/src/RateLimited.php
+++ b/src/RateLimited.php
@@ -128,7 +128,7 @@ class RateLimited
 
     protected function releaseDuration($job) :int
     {
-        if (!is_null($this->releaseAfterCallback)) {
+        if (! is_null($this->releaseAfterCallback)) {
             return call_user_func($this->releaseAfterCallback, [$job]);
         }
 

--- a/tests/RateLimitedTest.php
+++ b/tests/RateLimitedTest.php
@@ -57,6 +57,19 @@ class RateLimitedTest extends TestCase
         $this->middleware->enabled(false)->handle($this->job, $this->next);
     }
 
+    /** @test */
+    public function release_can_be_set_via_callback()
+    {
+        $this->job->shouldReceive('fire')->times(2);
+        $this->job->shouldReceive('release')->times(1)->with(2);
+
+        foreach (range(1, 3) as $i) {
+            $this->middleware->releaseAfter(static function(){
+                return 2;
+            })->handle($this->job, $this->next);
+        }
+    }
+
     private function mockRedis(): void
     {
         $this->redis = Mockery::mock(Connection::class);

--- a/tests/RateLimitedTest.php
+++ b/tests/RateLimitedTest.php
@@ -64,7 +64,7 @@ class RateLimitedTest extends TestCase
         $this->job->shouldReceive('release')->times(1)->with(2);
 
         foreach (range(1, 3) as $i) {
-            $this->middleware->releaseAfter(static function(){
+            $this->middleware->releaseAfter(static function () {
                 return 2;
             })->handle($this->job, $this->next);
         }


### PR DESCRIPTION
This PR allows to set a release duration value via callback.

For example, if I want to set a random value and this value should be different each time a job is dispatch, I use `releaseAfter` callback. At this time, if I set a random value on `releaseAfterSeconds` method, I will have the same value.