### PR TITLE
feat: Add a release after random seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ These methods are available to be called on the middleware. Their names should b
 - `releaseAfterSeconds(int $releaseInSeconds)`
 - `releaseAfterOneMinute()`
 - `releaseAfterMinutes(int $releaseInMinutes)`
-- `releaseAfter(callable $releaseAfter)`
+- `releaseAfterRandomSeconds(int $min = 1, int $max = 10)`
 
 ### Testing
 

--- a/src/RateLimited.php
+++ b/src/RateLimited.php
@@ -129,7 +129,7 @@ class RateLimited
     protected function releaseDuration() :int
     {
         if (! is_null($this->releaseRandomSeconds)) {
-            return $this->releaseRandomSeconds[array_rand($this->releaseRandomSeconds)];
+            return random_int(...$this->releaseRandomSeconds);
         }
 
         return $this->releaseInSeconds;

--- a/tests/RateLimitedTest.php
+++ b/tests/RateLimitedTest.php
@@ -58,7 +58,7 @@ class RateLimitedTest extends TestCase
     }
 
     /** @test */
-    public function release_can_be_set_via_callback()
+    public function release_can_be_set_with_random_seconds()
     {
         $this->job->shouldReceive('fire')->times(2);
         $this->job->shouldReceive('release')->times(1)->with(1);

--- a/tests/RateLimitedTest.php
+++ b/tests/RateLimitedTest.php
@@ -61,12 +61,11 @@ class RateLimitedTest extends TestCase
     public function release_can_be_set_via_callback()
     {
         $this->job->shouldReceive('fire')->times(2);
-        $this->job->shouldReceive('release')->times(1)->with(2);
+        $this->job->shouldReceive('release')->times(1)->with(1);
 
         foreach (range(1, 3) as $i) {
-            $this->middleware->releaseAfter(static function () {
-                return 2;
-            })->handle($this->job, $this->next);
+            $this->middleware->releaseAfterRandomSeconds(1, 1)
+                ->handle($this->job, $this->next);
         }
     }
 


### PR DESCRIPTION
After using `releaseAfter` method, I realized it doesn't work because `middlewares` are serialized and `closure` can't be serialize.

So, in this pull request I remove `releaseAfter` method and I put a `releaseAfterRandomSeconds` method which allow to set two values and when job will be release so a random value between these two values will returned.