### PR TITLE
Add feature exponential back-off to release logic

### DIFF
--- a/src/RateLimited.php
+++ b/src/RateLimited.php
@@ -128,9 +128,10 @@ class RateLimited
 
     public function releaseAfterBackoff(int $attemptedCount, int $backoffRate = 2)
     {
-        $releaseInSeconds = $this->releaseInSeconds * pow($backoffRate, $attemptedCount) - $this->releaseInSeconds;
+        $rateOffset = ($this->releaseInSeconds * $backoffRate) + $this->releaseInSeconds;
+        $releaseAfterSeconds = ($this->releaseInSeconds * pow($backoffRate, $attemptedCount)) - $rateOffset;
 
-        return $this->releaseAfterSeconds($releaseInSeconds);
+        return $this->releaseAfterSeconds($releaseAfterSeconds);
     }
     
     protected function releaseDuration(): int

--- a/src/RateLimited.php
+++ b/src/RateLimited.php
@@ -126,6 +126,13 @@ class RateLimited
         return $this;
     }
 
+    public function releaseAfterBackoff(int $attemptedCount, int $backoffRate = 2)
+    {
+        $releaseInSeconds = $this->releaseInSeconds * pow($backoffRate, $attemptedCount) - $this->releaseInSeconds;
+
+        return $this->releaseAfterSeconds($releaseInSeconds);
+    }
+    
     protected function releaseDuration(): int
     {
         if (! is_null($this->releaseRandomSeconds)) {

--- a/src/RateLimited.php
+++ b/src/RateLimited.php
@@ -128,12 +128,15 @@ class RateLimited
 
     public function releaseAfterBackoff(int $attemptedCount, int $backoffRate = 2)
     {
-        $rateOffset = ($this->releaseInSeconds * $backoffRate) + $this->releaseInSeconds;
-        $releaseAfterSeconds = ($this->releaseInSeconds * pow($backoffRate, $attemptedCount)) - $rateOffset;
+        $releaseAfterSeconds = 0;
+        $interval = $this->releaseInSeconds;
+        for($attempt = 0; $attempt <= $attemptedCount; $attempt++) {
+            $releaseAfterSeconds += $interval * pow($backoffRate, $attempt);
+        }
 
         return $this->releaseAfterSeconds($releaseAfterSeconds);
     }
-    
+
     protected function releaseDuration(): int
     {
         if (! is_null($this->releaseRandomSeconds)) {

--- a/tests/RateLimitedTest.php
+++ b/tests/RateLimitedTest.php
@@ -69,6 +69,40 @@ class RateLimitedTest extends TestCase
         }
     }
 
+    /** @test */
+    public function release_can_be_set_with_exponential_backoff()
+    {
+        $this->job->shouldReceive('fire')->times(2);
+        $this->job->shouldReceive('release')->with(15)->times(1);
+        $this->job->shouldReceive('release')->with(31)->times(1);
+        $this->job->shouldReceive('release')->with(63)->times(1);
+
+        foreach (range(1, 5) as $attempts) {
+            $this->middleware
+                ->releaseAfterSeconds(1)
+                ->releaseAfterBackoff($attempts)
+                ->handle($this->job, $this->next);
+        }
+
+    }
+
+    /** @test */
+    public function release_can_be_set_with_custom_exponential_backoff_rate()
+    {
+        $this->job->shouldReceive('fire')->times(2);
+        $this->job->shouldReceive('release')->with(40)->times(1);
+        $this->job->shouldReceive('release')->with(121)->times(1);
+        $this->job->shouldReceive('release')->with(364)->times(1);
+
+        foreach (range(1, 5) as $attempts) {
+            $this->middleware
+                ->releaseAfterSeconds(1)
+                ->releaseAfterBackoff($attempts, 3)
+                ->handle($this->job, $this->next);
+        }
+
+    }
+
     private function mockRedis(): void
     {
         $this->redis = Mockery::mock(Connection::class);


### PR DESCRIPTION
Adds exponential backoff ability to RateLimiter job middleware:

```
public function releaseAfterBackoff(int $attemptedCount, int $backoffRate = 2)
```

### Exampl 1

In this example, `releaseAfterBackoff()` inherits `RateLimiter::$releaseInSeconds` (5 seconds) and does not modify the backoff rate.

- Attempt 1: 5 seconds
- Attempt 2: 15 Seconds
- Attempt 3: 35 Seconds

```php
    // Job middleware method
    public function middleware()
    {
        return [(new RateLimited())
            ->allow(2)
            ->everySecond()
            ->releaseAfterBackoff($this->attempts());
        ];
    }
```

### Example 2

In this example, `releaseAfterBackoff()` uses the `RateLimiter::$releaseInSeconds` value as set by `releaseAfterMinute()` method.

- Attempt 1: 60 seconds
- Attempt 2: 180 Seconds
- Attempt 3: 420 Seconds

```php
    // Job middleware method
    public function middleware()
    {
        return [(new RateLimited())
            ->allow(2)
            ->everySecond()
            ->releaseAfterMinute()
            ->releaseAfterBackoff($this->attempts());
        ];
    }
```

### Example 3

In this example, `releaseAfterBackoff()` has the exponent set to "5" and uses the `RateLimiter::$releaseInSeconds` value as set by `releaseAfterSeconds()` method.

- Attempt 1: 2 seconds
- Attempt 2: 42 Seconds
- Attempt 3: 242 Seconds

```php
    // Job middleware method
    public function middleware()
    {
        return [(new RateLimited())
            ->allow(2)
            ->everySecond()
            ->releaseAfterSeconds(2)
            ->releaseAfterBackoff($this->attempts(), 5);
        ];
    }
```
