### PR TITLE
Fix "`$releaseInSeconds` must be of type int" exception

### DIFF
--- a/src/RateLimited.php
+++ b/src/RateLimited.php
@@ -129,7 +129,7 @@ class RateLimited
             $releaseAfterSeconds += $interval * pow($backoffRate, $attempt);
         }
 
-        return $this->releaseAfterSeconds($releaseAfterSeconds);
+        return $this->releaseAfterSeconds((int) $releaseAfterSeconds);
     }
 
     protected function releaseDuration(): int

--- a/tests/RateLimitedTest.php
+++ b/tests/RateLimitedTest.php
@@ -102,3 +102,7 @@ test('release can be set with custom exponential backoff rate', function (RateLi
             ->handle($this->job, $this->next);
     }
 })->with('middlewares');
+
+test('release after backoff can handle large number of attempts', function () {
+    expect((new RateLimited())->releaseAfterBackoff(60))->toBeInstanceOf(RateLimited::class);
+});


### PR DESCRIPTION
This PR resolves an exception that is generated when the number of attempts is >= 60 and calling `releaseAfterBackoff()`.

To reproduce:

```php
// Throws: RateLimited::releaseAfterSeconds(): Argument #1 ($releaseInSeconds) must be of type int
(new RateLimited())->releaseAfterBackoff(60);
```